### PR TITLE
Add support for legacy (aka. tunasync) status API

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,9 @@
 export default {
-    statusUrl: 'http://localhost:7001/lug/v1/manager',
-    mirrorBaseUrl: 'http://localhost:8000/', // don't miss the terminating slash
+    // statusUrl: 'http://localhost:7001/lug/v1/manager',
+    // statusVer: 'lug-v0',
+    statusUrl: 'https://mirrors.sjtug.org/static/tunasync.json',
+    statusVer: 'legacy',
+    // mirrorBaseUrl: 'http://localhost:8000/', // don't miss the terminating slash
+    mirrorBaseUrl: 'https://mirrors.sjtug.org/', // don't miss the terminating slash
     updateInterval: 30000,
 };

--- a/src/mirrorlist.vue
+++ b/src/mirrorlist.vue
@@ -38,7 +38,7 @@
         <div class="col s12">
             <h5>说明</h5>
             <ul>
-                <li>所有更新时间均为UTC +0。</li>
+                <li>若无明确指定，所有更新时间均为UTC +8。</li>
             </ul>
         </div>
     </div>

--- a/src/mutations.js
+++ b/src/mutations.js
@@ -5,6 +5,16 @@ import state from './state';
 
 export default {
     updateMirrorList() {
+        if (config.statusVer === 'lug-v0') {
+            this.updateML_lugv0();
+        } else if (config.statusVer === 'legacy') {
+            this.updateML_legacy();
+        } else {
+            console.log('updateMirrorList: unknown statusVer in config');
+        }
+    },
+
+    updateML_lugv0() {
         const fetched = fetch(config.statusUrl).then(response => response.json());
         fetched.catch((error) => {
             console.log(error.message);
@@ -41,6 +51,43 @@ export default {
             });
         });
     },
+
+    updateML_legacy() {
+        const fetched = fetch(config.statusUrl).then(response => response.json());
+        fetched.catch((error) => {
+            console.log(error.message);
+        });
+        fetched.then((j) => {
+            state.mirrorList.splice(0);
+            j.forEach((repo) => {
+                let statusClass = '';
+                let status = '';
+                if (repo.status === 'success') {
+                    statusClass = 'sync-finished';
+                    status = 'Idle'; // Hidden text
+                } else if (repo.status === 'syncing') {
+                    statusClass = 'sync-working';
+                    status = 'Syncing';
+                } else if (repo.status === 'failed') {
+                    statusClass = 'sync-failed';
+                    status = 'Failed';
+                } else {
+                    statusClass = 'sync-failed';
+                    status = 'Unknown';
+                }
+                // prettify the date string
+                const lastSync = repo.last_update;
+                state.mirrorList.push({
+                    name: repo.name,
+                    display_name: repo.name,
+                    last_sync: lastSync,
+                    status_class: statusClass,
+                    status,
+                });
+            });
+        });
+    },
+
     fetchHelps() {
         fetch('/data.json')
             .then(response => response.json())


### PR DESCRIPTION
Our site currently provides legacy status API introduced in tuna/tunasync#15 instead of our new lug-v0 API. Add support for it.

The date time string provided by the SJTUG mirror site is UTC+0-based, but the notice qinding the time as UTC+8 based. This should be fixed later on our server.