### PR TITLE
Fix incorrect URL when redirecting to a repo

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,7 +4,7 @@ export default {
   // Address of help articles
   helpAddress: 'https://sjtug-portal-1251836446.file.myqcloud.com/tags/mirror-help/index.xml',
   // All packages should be accessible at backendAddressBase + '/' + repo.name
-  backendAddressBase: '/',
+  backendAddressBase: '',
   // Address of the summary of backend in sjtug/lug format
   backendSummaryAddress: '/lug/v1/manager/summary'
 }


### PR DESCRIPTION
In #13 , when clicking on a repo, the browser will incorrectly be redirected to "//reponame" instead of '/reponame', hence causing problems.
