### PR TITLE
add scroll for `<code>` in docs

### DIFF
--- a/src/Docs.scss
+++ b/src/Docs.scss
@@ -21,7 +21,7 @@
     display: block;
     font-size: 16px;
     line-height: 20px;
-    overflow: hidden;
+    overflow: scroll;
     padding: 36px;
     white-space: inherit;
     word-wrap: normal;


### PR DESCRIPTION
<img width="543" alt="截屏2020-11-20 上午11 41 27" src="https://user-images.githubusercontent.com/13777628/99755282-55e83e00-2b25-11eb-89a6-50026f360306.png">

中小屏幕显示不全又不能scroll还挺难过的……
