### PR TITLE
ui: return to top after route change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,21 +3,24 @@ import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import Home from "./Home";
 import Docs from "./Docs";
 import Footer from "./Footer";
+import ScrollToTop from "./ScrollToTop";
 
 function App() {
   return (
     <Router>
-      <div>
-        <Switch>
-          <Route path="/docs">
-            <Docs />
-          </Route>
-          <Route path="/">
-            <Home />
-          </Route>
-        </Switch>
-      </div>
-      <Footer></Footer>
+      <ScrollToTop>
+        <div>
+          <Switch>
+            <Route path="/docs">
+              <Docs />
+            </Route>
+            <Route path="/">
+              <Home />
+            </Route>
+          </Switch>
+        </div>
+        <Footer></Footer>
+      </ScrollToTop>
     </Router>
   );
 }

--- a/src/ScrollToTop.js
+++ b/src/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useLayoutEffect } from "react";
+import { useLocation, withRouter } from "react-router-dom";
+
+function _ScrollToTop(props) {
+  const { pathname } = useLocation();
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return props.children;
+}
+
+export default withRouter(_ScrollToTop);


### PR DESCRIPTION
As currently the page keeps the absolute position after navigation, we prefer automatically return to top instead.