### PR TITLE
feat: link to mirrorz-help when no local help

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -26,6 +26,13 @@ export const BLOCKED_IN_ZHIYUAN = [
   // "homebrew-bottles",
 ];
 
+export const MIRRORZ_HELP_URL = "https://help.mirrors.cernet.edu.cn/";
+
+// sjtug name => mirrorz cname
+export const MIRRORZ_HELP = {
+  linuxmint: "linuxmint",
+};
+
 // These are legacy reverse proxy repos on Zhiyuan mirror.
 export const REVERSE_PROXY = [
   "docker-registry",

--- a/src/Home.js
+++ b/src/Home.js
@@ -17,6 +17,8 @@ import {
   HIDDEN,
   REVERSE_PROXY,
   MIRROR_INTEL,
+  MIRRORZ_HELP_URL,
+  MIRRORZ_HELP,
 } from "./Data";
 
 function baseOf(server) {
@@ -52,6 +54,12 @@ function transform(status, server) {
       : includes(MIRROR_INTEL, k)
       ? "Intel"
       : server,
+    mirrorz_help: k in MIRRORZ_HELP,
+    mirrorz_help_url:
+      MIRRORZ_HELP_URL +
+      (k in MIRRORZ_HELP ? MIRRORZ_HELP[k] : "") +
+      "/?mirror=SJTUG-" +
+      server,
   }));
 }
 

--- a/src/MirrorList.js
+++ b/src/MirrorList.js
@@ -66,6 +66,15 @@ function MirrorList({ summary }) {
               <Link className="ml-1" to={`/docs/${key}`}>
                 <BsInfoCircleFill />
               </Link>
+            ) : value.mirrorz_help ? (
+              <a
+                className="ml-1 mirrorz-help"
+                target="_blank"
+                rel="noreferrer"
+                href={value.mirrorz_help_url}
+              >
+                <BsInfoCircleFill />
+              </a>
             ) : (
               <Fragment></Fragment>
             )}

--- a/src/index.scss
+++ b/src/index.scss
@@ -31,3 +31,9 @@ body.dark-mode {
   background-color: #1a1919;
   color: #999;
 }
+
+.mirrorz-help,
+.mirrorz-help:hover {
+  // mirrorz blue
+  color: #15658a;
+}


### PR DESCRIPTION
Cc @PhotonQuantum

Further help can be linked by adding entries in `MIRRORZ_HELP`

Currently local help and mirrorz help use the same icon and the same color. It may use a different icon/color for distinguishability