### PR TITLE
Revert "fix: hide git repo (#71)"

### DIFF
--- a/src/MirrorList.js
+++ b/src/MirrorList.js
@@ -44,7 +44,6 @@ function Overlay({ key, value }) {
 function MirrorList({ summary }) {
   const rows = sortBy(Object.keys(summary), (k) => k.toLowerCase()).map(
     (key) => {
-      if (/git(hub)*\/.*/.test(key)) return null;
       const value = summary[key];
       const status = getStatus(value);
       return (


### PR DESCRIPTION
Repositories like `brew.git` are pure git repositories, and hiding them inconveniences our users. We may need to fold the git repos instead of hiding them. I unhide them for now, and a follow-up PR is welcome.

This reverts commit 02aa69122b10ea3d8a8a278812b5be7384ea9144.